### PR TITLE
build: Fix to use gcc-riscv64-linux-gnu

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ commands:
             export GCC5_ARM_PREFIX=arm-linux-gnueabi-
             export GCC5_AARCH64_PREFIX=aarch64-linux-gnu-
             export GCC5_LOONGARCH64_PREFIX=loongarch64-linux-gnu-
-            export GCC5_RISCV64_PREFIX=riscv64-unknown-elf-
+            export GCC5_RISCV64_PREFIX=riscv64-linux-gnu-
             source ./edksetup.sh
             build -q \
               -p ShellPkg/ShellPkg.dsc \
@@ -151,7 +151,7 @@ commands:
       - run:
           name: Build RiscVVirt
           command: |
-            export GCC5_RISCV64_PREFIX=riscv64-unknown-elf-
+            export GCC5_RISCV64_PREFIX=riscv64-linux-gnu-
             source ./edksetup.sh
             build -q \
               -p OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN \
     libmpc-dev \
     gcc-arm-linux-gnueabi \
     gcc-aarch64-linux-gnu \
-    gcc-riscv64-unknown-elf \
+    gcc-riscv64-linux-gnu \
   && ln -sf /usr/bin/python3 /usr/bin/python
 
 # Manually build and install binutils 2.43 for loongson (loongarch64)


### PR DESCRIPTION
Commit [1] adds -Wl,-z,notext flags for BFD/LLD, but the pre-built toolchain installed from Ubuntu packages does not support the option.

[1] https://github.com/tianocore/edk2/commit/188f8c686ed39b7b9998f1c2f4658ca8ba74b6ba